### PR TITLE
feat: add asset assignment management endpoints and service methods

### DIFF
--- a/backend/src/controllers/assetController.js
+++ b/backend/src/controllers/assetController.js
@@ -110,3 +110,89 @@ export const deleteAsset = async (req, res) => {
     });
   }
 };
+
+export const getAssetAssignments = async (req, res) => {
+  try {
+    const assignments = await assetService.listAssetAssignments(
+      req.params.id,
+      req.organization_id,
+      req.query,
+    );
+
+    if (!assignments) {
+      return res.status(404).json({
+        success: false,
+        message: 'Asset not found',
+      });
+    }
+
+    res.status(200).json({
+      success: true,
+      data: assignments,
+    });
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      message: error.message || 'Failed to fetch asset assignments',
+    });
+  }
+};
+
+export const assignAssetToEmployee = async (req, res) => {
+  try {
+    const { employee_id } = req.body;
+
+    if (!employee_id) {
+      return res.status(400).json({
+        success: false,
+        message: 'employee_id is required',
+      });
+    }
+
+    const assignment = await assetService.assignAssetToEmployee(
+      req.params.id,
+      req.organization_id,
+      req.body,
+    );
+
+    res.status(201).json({
+      success: true,
+      message: 'Asset assigned successfully',
+      data: assignment,
+    });
+  } catch (error) {
+    res.status(error.statusCode || 400).json({
+      success: false,
+      message: error.message || 'Failed to assign asset',
+    });
+  }
+};
+
+export const returnAssetAssignment = async (req, res) => {
+  try {
+    const assignment = await assetService.returnAssetAssignment(
+      req.params.id,
+      req.params.assignmentId,
+      req.organization_id,
+      req.body,
+    );
+
+    if (!assignment) {
+      return res.status(404).json({
+        success: false,
+        message: 'Asset assignment not found',
+      });
+    }
+
+    res.status(200).json({
+      success: true,
+      message: 'Asset assignment returned successfully',
+      data: assignment,
+    });
+  } catch (error) {
+    res.status(error.statusCode || 400).json({
+      success: false,
+      message: error.message || 'Failed to return asset assignment',
+    });
+  }
+};

--- a/backend/src/routes/assetRoutes.js
+++ b/backend/src/routes/assetRoutes.js
@@ -7,6 +7,13 @@ const router = express.Router();
 router.use(authenticate, tenantScope);
 
 router.get('/', assetController.getAllAssets);
+router.get('/:id/assignments', assetController.getAssetAssignments);
+router.post('/:id/assignments', authorize('ADMIN', 'MANAGER'), assetController.assignAssetToEmployee);
+router.patch(
+  '/:id/assignments/:assignmentId/return',
+  authorize('ADMIN', 'MANAGER'),
+  assetController.returnAssetAssignment,
+);
 router.get('/:id', assetController.getAssetById);
 router.post('/', authorize('ADMIN', 'MANAGER'), assetController.createAsset);
 router.put('/:id', authorize('ADMIN', 'MANAGER'), assetController.updateAsset);

--- a/backend/src/services/assetService.js
+++ b/backend/src/services/assetService.js
@@ -30,6 +30,37 @@ const assetSelect = {
   },
 };
 
+const assetAssignmentSelect = {
+  id: true,
+  asset_id: true,
+  employee_id: true,
+  assigned_at: true,
+  returned_at: true,
+  notes: true,
+  created_at: true,
+  updated_at: true,
+  asset: {
+    select: {
+      id: true,
+      asset_tag_uid: true,
+      asset_type: true,
+      model: true,
+      serial_number: true,
+      status: true,
+    },
+  },
+  employee: {
+    select: {
+      id: true,
+      employee_code: true,
+      name: true,
+      email: true,
+      status: true,
+      is_active: true,
+    },
+  },
+};
+
 export const listAssets = async (organizationId, filters = {}) => {
   const normalizedOrganizationId = toIntOrNull(organizationId);
 
@@ -173,4 +204,182 @@ export const deleteAsset = async (id, organizationId) => {
   });
 
   return { success: true, message: 'Asset deleted successfully' };
+};
+
+export const listAssetAssignments = async (assetId, organizationId, filters = {}) => {
+  const normalizedAssetId = toIntOrNull(assetId);
+  const normalizedOrganizationId = toIntOrNull(organizationId);
+
+  if (normalizedAssetId === null || normalizedOrganizationId === null) {
+    return null;
+  }
+
+  const asset = await prisma.asset.findFirst({
+    where: {
+      id: normalizedAssetId,
+      organization_id: normalizedOrganizationId,
+    },
+    select: { id: true },
+  });
+
+  if (!asset) {
+    return null;
+  }
+
+  const where = {
+    asset_id: normalizedAssetId,
+  };
+
+  if (String(filters.active).toLowerCase() === 'true') {
+    where.returned_at = null;
+  }
+
+  return prisma.assetAssignment.findMany({
+    where,
+    select: assetAssignmentSelect,
+    orderBy: {
+      assigned_at: 'desc',
+    },
+  });
+};
+
+export const assignAssetToEmployee = async (assetId, organizationId, assignmentData) => {
+  const normalizedAssetId = toIntOrNull(assetId);
+  const normalizedOrganizationId = toIntOrNull(organizationId);
+  const normalizedEmployeeId = toIntOrNull(assignmentData.employee_id);
+
+  if (normalizedAssetId === null || normalizedOrganizationId === null) {
+    throw new Error('Invalid asset_id');
+  }
+
+  if (normalizedEmployeeId === null) {
+    throw new Error('employee_id is required');
+  }
+
+  const asset = await prisma.asset.findFirst({
+    where: {
+      id: normalizedAssetId,
+      organization_id: normalizedOrganizationId,
+    },
+    select: {
+      id: true,
+      status: true,
+    },
+  });
+
+  if (!asset) {
+    const error = new Error('Asset not found');
+    error.statusCode = 404;
+    throw error;
+  }
+
+  if (asset.status !== 'ACTIVE') {
+    const error = new Error('Only ACTIVE assets can be assigned');
+    error.statusCode = 400;
+    throw error;
+  }
+
+  const employee = await prisma.employee.findFirst({
+    where: {
+      id: normalizedEmployeeId,
+      organization_id: normalizedOrganizationId,
+    },
+    select: {
+      id: true,
+      is_active: true,
+      status: true,
+    },
+  });
+
+  if (!employee) {
+    const error = new Error('Employee not found');
+    error.statusCode = 404;
+    throw error;
+  }
+
+  if (!employee.is_active || employee.status !== 'ACTIVE') {
+    const error = new Error('Only active employees can receive asset assignments');
+    error.statusCode = 400;
+    throw error;
+  }
+
+  const activeAssignment = await prisma.assetAssignment.findFirst({
+    where: {
+      asset_id: normalizedAssetId,
+      returned_at: null,
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  if (activeAssignment) {
+    const error = new Error('Asset already has an active assignment');
+    error.statusCode = 409;
+    throw error;
+  }
+
+  return prisma.assetAssignment.create({
+    data: {
+      asset_id: normalizedAssetId,
+      employee_id: normalizedEmployeeId,
+      assigned_at: assignmentData.assigned_at ? new Date(assignmentData.assigned_at) : new Date(),
+      notes: assignmentData.notes || null,
+    },
+    select: assetAssignmentSelect,
+  });
+};
+
+export const returnAssetAssignment = async (assetId, assignmentId, organizationId, returnData = {}) => {
+  const normalizedAssetId = toIntOrNull(assetId);
+  const normalizedAssignmentId = toIntOrNull(assignmentId);
+  const normalizedOrganizationId = toIntOrNull(organizationId);
+
+  if (
+    normalizedAssetId === null ||
+    normalizedAssignmentId === null ||
+    normalizedOrganizationId === null
+  ) {
+    return null;
+  }
+
+  const assignment = await prisma.assetAssignment.findFirst({
+    where: {
+      id: normalizedAssignmentId,
+      asset_id: normalizedAssetId,
+      asset: {
+        organization_id: normalizedOrganizationId,
+      },
+    },
+    select: {
+      id: true,
+      returned_at: true,
+    },
+  });
+
+  if (!assignment) {
+    return null;
+  }
+
+  if (assignment.returned_at) {
+    const error = new Error('Asset assignment has already been returned');
+    error.statusCode = 409;
+    throw error;
+  }
+
+  const data = {
+    returned_at: returnData.returned_at ? new Date(returnData.returned_at) : new Date(),
+  };
+
+  if (returnData.notes !== undefined) {
+    data.notes = returnData.notes || null;
+  }
+
+  return prisma.assetAssignment.update({
+    where: {
+      id: normalizedAssignmentId,
+    },
+    data,
+    select: assetAssignmentSelect,
+  });
 };


### PR DESCRIPTION
This pull request introduces a new asset assignment feature, allowing assets to be assigned to employees, tracked, and returned. It includes new API endpoints, service methods, and data selection logic to support these operations.

**Asset Assignment Feature**

* Added API endpoints to:
  * List all assignments for a specific asset (`GET /:id/assignments`)
  * Assign an asset to an employee (`POST /:id/assignments`) with admin/manager authorization
  * Return an asset assignment (`PATCH /:id/assignments/:assignmentId/return`) with admin/manager authorization
* Implemented controller methods for listing assignments, assigning assets, and returning assignments in `assetController.js`

**Service Layer Enhancements**

* Added `assetAssignmentSelect` to define fields returned for assignment queries, including nested asset and employee details
* Implemented service methods in `assetService.js`:
  * `listAssetAssignments` for fetching assignments, supporting filtering for active assignments
  * `assignAssetToEmployee` with validation (asset and employee must be active, asset must not be already assigned)
  * `returnAssetAssignment` to mark an assignment as returned, with validation to prevent duplicate returns